### PR TITLE
Concierge: new: [PET-3999]: Update the concierge SDK to 5.1.5 and make sure repo directed to s3.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
     implementation 'com.google.android.material:material:1.6.0'
-    implementation 'com.flybits.android:concierge:5.1.4' // Update to 5.1.4
     implementation 'com.google.firebase:firebase-core:18.0.2'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
@@ -48,9 +47,12 @@ dependencies {
     implementation 'com.facebook.stetho:stetho-okhttp3:1.5.1'
     implementation 'androidx.work:work-runtime-ktx:2.7.1'
 
+    // Concierge dependency
+    implementation 'com.flybits.android:concierge:5.1.5' // Updated to 5.1.5
+
     // Huawei dependency
-    implementation "com.flybits.android:huawei-push:5.1.4"
-    implementation "com.flybits.android:huawei-location:5.1.4"
+    implementation "com.flybits.android:huawei-push:5.1.5"
+    implementation "com.flybits.android:huawei-location:5.1.5"
 }
 
 apply plugin: 'com.google.gms.google-services'


### PR DESCRIPTION
Update the concierge SDK to 5.1.5 and make sure repo directed to s3. 
Compiles and runs.